### PR TITLE
fix Payment Verification condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ zarinpal.PaymentVerification({
   Amount: '1000', // In Tomans
   Authority: '000000000000000000000000000000000000',
 }).then(response => {
-  if (response.status === -21) {
+  if (response.status !== 100) {
     console.log('Empty!');
   } else {
     console.log(`Verified! Ref ID: ${response.RefID}`);


### PR DESCRIPTION
if only check -21 error we lose other error that may have happened.
 e.g. if the amount input is incorrect, returned status will be -33 and RefID will be 0.