### PR TITLE
throw error instead of error message + throw error if merchantId is not string

### DIFF
--- a/lib/zarinpal.js
+++ b/lib/zarinpal.js
@@ -52,7 +52,7 @@ ZarinPal.prototype.PaymentRequest = function(input) {
 				url: config.PG(self.sandbox) + data.Authority
 			});
 		}).catch(function (err) {
-			reject(err.message);
+			reject(err);
 		});
 	});
 
@@ -80,7 +80,7 @@ ZarinPal.prototype.PaymentVerification = function(input) {
 				RefID: data.RefID
 			});
 		}).catch(function (err) {
-			reject(err.message);
+			reject(err);
 		});
 	});
 
@@ -106,7 +106,7 @@ ZarinPal.prototype.UnverifiedTransactions = function() {
 				authorities: data.Authorities
 			});
 		}).catch(function (err) {
-			reject(err.message);
+			reject(err);
 		});
 	});
 
@@ -133,7 +133,7 @@ ZarinPal.prototype.RefreshAuthority = function(input) {
 				status: data.Status
 			});
 		}).catch(function (err) {
-			reject(err.message);
+			reject(err);
 		});
 	});
 

--- a/lib/zarinpal.js
+++ b/lib/zarinpal.js
@@ -12,11 +12,13 @@ var config  = require('./config');
  * @param {bool} sandbox
  */
 function ZarinPal(MerchantID, sandbox) {
-	if (typeof MerchantID === 'string' && MerchantID.length === config.merchantIDLength) {
+  if(typeof MerchantID !== 'string'){
+      throw new Error("MerchantId is invalid");
+  }
+	if (MerchantID.length === config.merchantIDLength) {
 		this.merchant = MerchantID;
 	} else {
 		console.error('The MerchantID must be ' + config.merchantIDLength + ' Characters.');
-		return false;
 	}
 	this.sandbox = sandbox || false;
 


### PR DESCRIPTION
throw error instead of error message : 
error should be returned for throw argument not string. 
this will give stack of error to the developer to find out what is going on ( when error happened )

throw error if merchantId is not string : 
this one was in my case . it took me a long time to realize that I had passed undefined for merchantId
because Error happened in another method (paymentRequest)
