### PR TITLE
refactor: remove axios dependency and switch to native fetch client

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {
-    "axios": "^1.9.0"
-  },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.60.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      axios:
-        specifier: ^1.9.0
-        version: 1.15.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -402,12 +398,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -421,10 +411,6 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -440,10 +426,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -474,28 +456,8 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   escape-string-regexp@4.0.0:
@@ -584,19 +546,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -604,14 +553,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -629,21 +570,9 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -723,18 +652,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -796,10 +713,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1212,16 +1125,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  asynckit@0.4.0: {}
-
-  axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -1235,11 +1138,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
   callsites@3.1.0: {}
 
   chalk@4.1.2:
@@ -1252,10 +1150,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
 
   commondir@1.0.1: {}
 
@@ -1277,28 +1171,7 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  delayed-stream@1.0.0: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  es-define-property@1.0.1: {}
-
   es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   escape-string-regexp@4.0.0: {}
 
@@ -1398,38 +1271,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
 
   glob-parent@6.0.2:
     dependencies:
@@ -1445,15 +1290,7 @@ snapshots:
 
   globals@16.5.0: {}
 
-  gopd@1.2.0: {}
-
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -1522,14 +1359,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  math-intrinsics@1.1.0: {}
-
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -1584,8 +1413,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   prelude-ls@1.2.1: {}
-
-  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,7 +20,6 @@ export default [
         exports: 'named'
       }
     ],
-    external: ['axios'],
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig, AxiosResponse } from 'axios';
-
 export type Currency = 'IRR' | 'IRT';
 
 export interface PaymentRequestInput {
@@ -55,16 +53,32 @@ export interface ZarinPalError {
   };
 }
 
+export interface HttpRequestConfig {
+  url: string;
+  method: 'POST';
+  data: unknown;
+}
+
+export interface HttpResponse<T = unknown> {
+  data: T;
+}
 
 export interface HttpClient {
-  request: <T = unknown>(config: AxiosRequestConfig) => Promise<AxiosResponse<T>>;
+  request: <T = unknown>(config: HttpRequestConfig) => Promise<HttpResponse<T>>;
+}
+
+export interface DefaultHttpClientOptions {
+  timeoutMs?: number;
+  headers?: Record<string, string>;
 }
 
 export interface ZarinPalClientOptions {
   sandbox?: boolean;
   currency?: Currency;
   timeoutMs?: number;
-  axiosConfig?: Omit<AxiosRequestConfig, 'method' | 'url' | 'data'>;
+  requestConfig?: Omit<DefaultHttpClientOptions, 'timeoutMs'>;
+  /** @deprecated Use requestConfig instead. */
+  axiosConfig?: Omit<DefaultHttpClientOptions, 'timeoutMs'>;
   httpClient?: HttpClient;
 }
 

--- a/src/zarinpal.ts
+++ b/src/zarinpal.ts
@@ -1,8 +1,10 @@
-import axios from 'axios';
 // @ts-ignore TS5097: Node ESM tests require explicit .ts extension.
 import { API_BASE_URL, API_PATHS, MERCHANT_ID_LENGTH, START_PAY_BASE_URL } from './config.ts';
 import type {
   Currency,
+  HttpClient,
+  HttpRequestConfig,
+  HttpResponse,
   PaymentRequestInput,
   PaymentRequestResponse,
   PaymentVerificationInput,
@@ -11,8 +13,7 @@ import type {
   RefreshAuthorityResponse,
   UnverifiedTransactionsResponse,
   ZarinPalClientOptions,
-  ZarinPalError,
-  HttpClient
+  ZarinPalError
 } from './types.ts';
 
 interface RequestPayload {
@@ -41,7 +42,76 @@ interface ApiData {
   fee?: number;
 }
 
+interface HttpErrorData {
+  errors?: ZarinPalError['errors'];
+}
+
+interface HttpError extends Error {
+  response?: {
+    data?: HttpErrorData;
+  };
+}
+
 const VALID_CURRENCIES = new Set<Currency>(['IRR', 'IRT']);
+const DEFAULT_HEADERS = {
+  accept: 'application/json',
+  'content-type': 'application/json'
+} as const;
+
+class FetchHttpClient implements HttpClient {
+  private readonly timeoutMs: number;
+  private readonly headers: Record<string, string>;
+
+  public constructor(options: ZarinPalClientOptions) {
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.headers = {
+      ...DEFAULT_HEADERS,
+      ...(options.requestConfig?.headers ?? {}),
+      ...(options.axiosConfig?.headers ?? {})
+    };
+  }
+
+  public async request<T>(config: HttpRequestConfig): Promise<HttpResponse<T>> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(config.url, {
+        method: config.method,
+        headers: this.headers,
+        body: JSON.stringify(config.data),
+        signal: controller.signal
+      });
+
+      const parsedData = await response.json() as T | HttpErrorData;
+
+      if (!response.ok) {
+        const httpError = new Error(`Request failed with status ${response.status}`) as HttpError;
+        httpError.response = { data: parsedData as HttpErrorData };
+        throw httpError;
+      }
+
+      return { data: parsedData as T };
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`Request timed out after ${this.timeoutMs}ms`);
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function hasApiError(error: unknown): error is HttpError {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const responseData = (error as HttpError).response?.data;
+  return responseData !== undefined && typeof responseData === 'object' && responseData !== null && 'errors' in responseData;
+}
 
 export class ZarinPalCheckout {
   public readonly merchant: string;
@@ -62,14 +132,7 @@ export class ZarinPalCheckout {
       throw new Error("Invalid currency. Valid options are 'IRR' or 'IRT'.");
     }
 
-    this.client = options.httpClient ?? axios.create({
-      timeout: options.timeoutMs ?? 10_000,
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json'
-      },
-      ...options.axiosConfig
-    });
+    this.client = options.httpClient ?? new FetchHttpClient(options);
   }
 
   public async PaymentRequest(input: PaymentRequestInput): Promise<PaymentRequestResponse> {
@@ -161,7 +224,7 @@ export class ZarinPalCheckout {
 
       return response.data.data;
     } catch (error: unknown) {
-      if (axios.isAxiosError<{ errors?: ZarinPalError['errors'] }>(error) && error.response?.data?.errors) {
+      if (hasApiError(error) && error.response?.data?.errors) {
         throw error.response.data;
       }
 


### PR DESCRIPTION
### Motivation
- Remove the runtime dependency on `axios` in favor of a smaller, dependency-free HTTP implementation to reduce bundle size and surface area.
- Provide a lightweight default client with the same JSON POST semantics and timeout behavior while keeping `httpClient` injection for testing and advanced use-cases.

### Description
- Added a `FetchHttpClient` (native `fetch` + `AbortController`) implementation and a `hasApiError` helper to normalize API error rethrows in `src/zarinpal.ts`, and switched the default client to use it while preserving `httpClient` injection. 
- Implemented timeout handling, JSON request body encoding, and preserved `response.data.errors` rethrow semantics when the API returns validation errors. 
- Replaced Axios-specific types with generic `HttpRequestConfig`/`HttpResponse`/`HttpClient` contracts and introduced `requestConfig` plus a deprecated `axiosConfig` alias in `src/types.ts` to maintain backwards compatibility. 
- Removed `axios` from `package.json` dependencies and from Rollup `external` so the package no longer depends on Axios at runtime. 

### Testing
- Ran `npm test` and all unit tests passed (`45` tests, `0` failures). 
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed successfully. 
- Ran `npm run lint` but linting failed in this environment due to missing ESLint package resolution (`@eslint/js`) unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfa75625dc832791a6d2b80524151a)